### PR TITLE
Improve deploys

### DIFF
--- a/lib/utils/s3-tool.js
+++ b/lib/utils/s3-tool.js
@@ -144,13 +144,11 @@ module.exports.uploadFile = function(s3, ui, fullPath, params) {
  */
 function buildFileParameters(filePath, options) {
   options = options || {};
-  var expires = new Date(new Date().getTime() + 360000);
   var mimeType = mime.lookup(filePath);
   var params = {
     Key: filePath,
     ACL: 'public-read',
-    CacheControl: "max-age=3600, public",
-    Expires: expires,
+    CacheControl: "max-age=31536000, public",
     ContentType: mimeType
   };
   return extend(params, options);

--- a/lib/utils/s3-tool.js
+++ b/lib/utils/s3-tool.js
@@ -8,6 +8,7 @@ var async     = require('async');
 var path      = require('path');
 var mime      = require('mime');
 var fs        = require('fs');
+var execSync  = require('execSync');
 
 mime.default_type = 'text/plain';
 
@@ -145,11 +146,15 @@ module.exports.uploadFile = function(s3, ui, fullPath, params) {
 function buildFileParameters(filePath, options) {
   options = options || {};
   var mimeType = mime.lookup(filePath);
+  var isGzip = !execSync.run('gzip -t "'+filePath+'" 2> /dev/null');
   var params = {
     Key: filePath,
     ACL: 'public-read',
     CacheControl: "max-age=31536000, public",
     ContentType: mimeType
   };
+  if (isGzip) {
+    params.ContentEncoding = 'gzip';
+  }
   return extend(params, options);
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,12 @@
     "aws-sdk": "2.0.19",
     "chalk": "0.5.1",
     "core-object": "0.0.2",
+    "dargs": "2.1.0",
+    "execSync": "^1.0.2",
     "extend": "2.0.0",
     "mime": "1.2.11",
     "readdirp": "1.1.0",
-    "rsvp": "3.0.14",
-    "dargs": "2.1.0",
-    "requiring": "0.0.3"
+    "requiring": "0.0.3",
+    "rsvp": "3.0.14"
   }
 }


### PR DESCRIPTION
These changes make cache headers longer than just an hour, and add detection of gzipped files when publishing assets.