### PR TITLE
Default cli options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@
 language: node_js
 
 node_js:
-  - '0.10'
+  - '0.10.36'
   - '0.11'
+  - '0.12'
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # ember-cli-s3-sync Changelog
+
+### 0.0.5
+
+
+
+* [FEATURE] allow default cli-args when running custom scripts during deploy process
+
 ### 0.0.4
 
 This release introduces better formatted for running extra-step commands and more test coverage.

--- a/lib/tasks/extra-step.js
+++ b/lib/tasks/extra-step.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var command = require('../utils/command');
+var command = require('../utils/cmd-tool');
 var RSVP    = require('rsvp');
 var chalk   = require('chalk');
 

--- a/lib/utils/cmd-tool.js
+++ b/lib/utils/cmd-tool.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var Promise = require('../ext/promise');
+var extend  = require('extend');
 var dargs   = require('dargs');
 var chalk   = require('chalk');
 var exec    = require('child_process').exec;
-
 
 /*
  *  Turns an array of `key=value` into proper command-line arguments and flags.
@@ -38,6 +38,61 @@ function formatArguments(args) {
 }
 
 /*
+ *  Considers any default hashes, from the `includes` Array, to build the
+ *  hash of all available options. The actual supplied cli-arguments
+ *  (the ones you types into the shell) take precedence and are merged into the defaults.
+ *
+ *  @method buildOptionsWithDefaults
+ *  @param {Object} options
+ *  @param {Array} includes
+ *  @return {Object} a new options hash with default options merged in
+ *
+ */
+function optionsWithDefaults(options, includes) {
+  includes = includes || [];
+  var opts = {};
+
+  includes.forEach(function(arg, i) {
+    if ('string' === typeof arg) {
+      return;
+    }
+    extend(opts, arg);
+  });
+
+  return extend(opts, options);
+}
+
+/*
+ *  Returns a new Array where all elements are strings.
+ *  Default hashes are replaced with their key. For example:
+ *  `['foo', { myOption: 'my value' }]` becomes:
+ *  `['foo', 'myOption']`
+ *
+ *  @method buildOptionsWithDefaults
+ *  @param {Object} options
+ *  @param {Array} includes
+ *  @return {Object} a modified options hash with default options merged in
+ *
+ */
+function includesWithDefaults(includes) {
+  includes = includes || [];
+  var key;
+  var incl = [];
+
+  includes.forEach(function(arg, i) {
+    if ('string' === typeof arg) {
+     return incl.push(arg);
+    }
+
+    for (key in arg) {
+      incl.push(key);
+    }
+  });
+
+  return incl;
+}
+
+/*
  *  @method build
  *  @param {String} command The base command to run
  *  @param {Object} options Available options
@@ -50,11 +105,14 @@ function build(command, options, includes) {
     return;
   }
 
-  command = command.trim();
-  options = options || {};
   includes = includes || [];
+  options = options || {};
+  command = command.trim();
 
-  var args = dargs(options, [], includes);
+  var opts = optionsWithDefaults(options, includes);
+  var incl = includesWithDefaults(includes);
+  var args = dargs(opts, [], incl);
+
   var formattedArgs = formatArguments(args);
 
   command += !!formattedArgs ? ' ' + formattedArgs : '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-s3-sync",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "directories": {
     "doc": "doc",

--- a/tests/unit/utils/cmd-tool-test.js
+++ b/tests/unit/utils/cmd-tool-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert    = require('assert');
-var command = require('../../../lib/utils/command');
+var command = require('../../../lib/utils/cmd-tool');
 
 describe('Command', function() {
   var dummyCommand = ' echo "command test" ';
@@ -9,6 +9,8 @@ describe('Command', function() {
   var dummyIncludes = ['foo', 'falsy', 'num'];
 
   var dummyIncludesTwo = ['truthy', 'someOption', 'nonExistent'];
+
+  var includesWithDefaults = ['foo', { truthy: 'yes!' }, { notProvided: 'i am a default' }];
 
   var dummyOptions = {
     foo: 'bar',
@@ -35,6 +37,13 @@ describe('Command', function() {
   it('Builds properly formatted command with truthy, string, and ignores non-existent cli options', function() {
     var actual = command.build(dummyCommand, dummyOptions, dummyIncludesTwo);
     var expect = 'echo "command test" --truthy --some-option "i am spacey"';
+
+    assert.equal(actual, expect, 'Command formatted correctly');
+  });
+
+  it('Builds properly formatted command using default args when no arg is provided', function() {
+    var actual = command.build(dummyCommand, dummyOptions, includesWithDefaults);
+    var expect = 'echo "command test" --truthy --not-provided "i am a default" --foo bar';
 
     assert.equal(actual, expect, 'Command formatted correctly');
   });


### PR DESCRIPTION
Adds ability to provide default cli-args when running a custom script between deploy steps. 

The motivation is that you probably don't want to pass in a billion cli-args when running `ember deploy:s3` and are likely to employ defaults instead but want the ability to override those defaults.

e.g. in your *deploy/config.js*
```javascript
{
  ...
  afterDeploy: [
    {
      command: 'curl http://httpbin.com/headers',
      includeOptions: ['compressed', { header: 'X-Update: 1' }, { head: true }],
      fail: false
    }  
  ],
  ...
}
```
and running: `ember deploy:s3`
will build and run this command after a successful push of assets to S3:
`curl http://httpbin.com/headers --header "X-Update: 1" --head`

and running: `ember deploy:s3 --header="X-Forwarded-For: mysite.com"`
will build and run this command:
`curl http://httpbin.com/headers --header "X-Forwarded-For: mysite.com" --head`