### PR TITLE
Fix typo in config blueprint

### DIFF
--- a/blueprints/config-s3/files/deploy/config.js
+++ b/blueprints/config-s3/files/deploy/config.js
@@ -112,7 +112,7 @@ var productionConfig = {
   options: developmentConfig.options
 };
 
-var configs: {
+var configs = {
   development: developmentConfig,
   production: productionConfig
 };


### PR DESCRIPTION
This causes an unexpected token error, it should be `=`