### PR TITLE
Update misnamed variable in config blueprint

### DIFF
--- a/blueprints/config-s3/files/deploy/config.js
+++ b/blueprints/config-s3/files/deploy/config.js
@@ -133,8 +133,8 @@ module.exports = function configFile(name, environment) {
 
   if (!configuration && environment) {
     for (var key in configs) {
-      if (config[key]['environment'] === environment) {
-        configuration = config[key];
+      if (configs[key]['environment'] === environment) {
+        configuration = configs[key];
       }
     }
   }


### PR DESCRIPTION
The variable `config` does not exist, it should be `configs`